### PR TITLE
Revert security hole introduced by https://github.com/Stouts/Stouts.postfix/pull/3

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,6 @@
 ---
-
-- name: Ensure /etc/postfix directory is owned by postfix user
-  file: path=/etc/postfix owner=postfix
+- name: Ensure /etc/postfix directory is owned by root user
+  file: path=/etc/postfix owner=root
   notify: postfix restart
 
 - name: Configure postfix pt. 1


### PR DESCRIPTION
The 'bug' referred to in the above PR is not actually a bug, but a vital
part of security of postfix.

If an attacker ever gets access to a process running as the 'postfix'
user, and /etc/postfix is owned the postfix user, they would be able to
re-configure the postfix itself by renaming or editing files in
/etc/postfix.

The config changes they could then introduce would change the postfix
processes to run as root, which would mean they can get root access.

For example an attacker could change the 'unpriv' and 'chroot' flags in
/etc/postfix/master.cf and they would then be able to leapfrog to the
root user, where they were previously restricted.

If there are permission problems when reconfiguring postfix, the user
should instead use 'sudo'. Or change the permissions on the specific
files that have the problem, not the base directory.
